### PR TITLE
긴 어절이 있을 때 발생하는 줄넘김 문제 해결 및 테스트를 위한 코드 추가

### DIFF
--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -8,23 +8,15 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:example/main.dart';
+import 'package:word_break_text/word_break_text.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+  testWidgets('Example word breaking test', (WidgetTester tester) async {
+    const sentence = '헬로월드. 이것은 긴 문장입니다. 작은 화면에서 단어를 기준으로 줄바꿈이 되어야 합니다.';
+    await tester.pumpWidget(
+      const MaterialApp(home: Scaffold(body: WordBreakText(sentence))),
+    );
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
+    expect(find.wordBreakText(sentence), findsOneWidget);
   });
 }

--- a/lib/testing.dart
+++ b/lib/testing.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:word_break_text/word_break_text.dart';
+
+extension WordBreakTextFinder on CommonFinders {
+  Finder wordBreakText(String text) {
+    return _WordBreakTextFinder(text);
+  }
+}
+
+class _WordBreakTextFinder extends MatchFinder {
+  _WordBreakTextFinder(this.text, {bool skipOffstage = true})
+      : super(skipOffstage: skipOffstage);
+
+  final String text;
+
+  @override
+  String get description => 'word break text "$text"';
+
+  @override
+  bool matches(Element candidate) {
+    final Widget widget = candidate.widget;
+    if (widget is WordBreakText) {
+      return widget.data == text;
+    }
+    return false;
+  }
+}

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+Size getTextSize(BuildContext context, String text, TextStyle style) {
+  final TextPainter textPainter = TextPainter(
+    text: TextSpan(text: text, style: style),
+    maxLines: 1,
+    textDirection: TextDirection.ltr,
+    textScaleFactor: MediaQuery.of(context).textScaleFactor,
+  )..layout(minWidth: 0, maxWidth: double.infinity);
+  return textPainter.size;
+}

--- a/lib/word_break_text.dart
+++ b/lib/word_break_text.dart
@@ -109,46 +109,6 @@ class WordBreakText extends StatelessWidget {
   /// only the [spacing] of the Wrap widget is used.
   final bool spacingByWrap;
 
-  List<String> _splitData(BuildContext context, double maxWidth) {
-    double textWidthOf(String text) {
-      return getTextSize(
-              context, text, style ?? DefaultTextStyle.of(context).style)
-          .width;
-    }
-    /// Returns an index of text that is cut at the max width.
-    int getCutIndexOf(String text) {
-      int lo = -1;
-      int hi = text.length;
-      while (lo + 1 < hi) {
-        int mid = ((lo + hi) / 2).floor();
-        if (textWidthOf(text.substring(0, mid)) < maxWidth) {
-          lo = mid;
-        } else {
-          hi = mid;
-        }
-      }
-      return lo;
-    }
-
-    final list =
-        data.split(' ').where((element) => element.trim() != '').toList();
-    final result = <String>[];
-
-    for (int i = 0; i < list.length; ++i) {
-      result.add(list[i]);
-      // 한 어절 단위가 최대 너비보다 크다면 최대 너비 사이즈마다 단어를 쪼갠다.
-      while (textWidthOf(result.last) > maxWidth) {
-        final overflowingText = result.last;
-        result.removeLast();
-
-        int cutIndex = getCutIndexOf(overflowingText);
-        result.add(overflowingText.substring(0, cutIndex));
-        result.add(overflowingText.substring(cutIndex, overflowingText.length));
-      }
-    }
-    return result;
-  }
-
   const WordBreakText(
     this.data, {
     Key? key,
@@ -187,6 +147,47 @@ class WordBreakText extends StatelessWidget {
         spacing: spacing,
       );
     });
+  }
+
+  List<String> _splitData(BuildContext context, double maxWidth) {
+    double textWidthOf(String text) {
+      return getTextSize(
+              context, text, style ?? DefaultTextStyle.of(context).style)
+          .width;
+    }
+
+    /// Returns an index of text that is cut at the max width.
+    int getCutIndexOf(String text) {
+      int lo = -1;
+      int hi = text.length;
+      while (lo + 1 < hi) {
+        int mid = ((lo + hi) / 2).floor();
+        if (textWidthOf(text.substring(0, mid)) < maxWidth) {
+          lo = mid;
+        } else {
+          hi = mid;
+        }
+      }
+      return lo;
+    }
+
+    final list =
+        data.split(' ').where((element) => element.trim() != '').toList();
+    final result = <String>[];
+
+    for (int i = 0; i < list.length; ++i) {
+      result.add(list[i]);
+      // 한 어절 단위가 최대 너비보다 크다면 최대 너비 사이즈마다 단어를 쪼갠다.
+      while (textWidthOf(result.last) > maxWidth) {
+        final overflowingText = result.last;
+        result.removeLast();
+
+        int cutIndex = getCutIndexOf(overflowingText);
+        result.add(overflowingText.substring(0, cutIndex));
+        result.add(overflowingText.substring(cutIndex, overflowingText.length));
+      }
+    }
+    return result;
   }
 
   Text _mapTextWidget(mapEntry, int lastIndex) {

--- a/lib/word_break_text.dart
+++ b/lib/word_break_text.dart
@@ -1,5 +1,7 @@
 library word_break_text;
 
+export 'package:word_break_text/testing.dart';
+
 import 'package:flutter/material.dart';
 import 'package:word_break_text/utils.dart';
 

--- a/test/word_break_text_test.dart
+++ b/test/word_break_text_test.dart
@@ -1,5 +1,42 @@
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:word_break_text/utils.dart';
 
 import 'package:word_break_text/word_break_text.dart';
 
-void main() {}
+void main() {
+  testWidgets('The width of each text is less than the max-width',
+      (tester) async {
+    const TextStyle textStyle = TextStyle(fontSize: 40);
+    late final double maxWidth;
+
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: LayoutBuilder(builder: (context, constraints) {
+          maxWidth = constraints.maxWidth;
+          return const WordBreakText(
+            '이것은매우매우매우매우매우매우매우매우매우매우매우매우매우매우매우긴어절이고 여기는 짧은 어절입니다. 테스트용입니다.',
+            style: textStyle,
+          );
+        }),
+      ),
+    ));
+
+    final textWidgets = tester.widgetList<Text>(find.byType(Text));
+    // Using the Builder for getting context.
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Builder(
+          builder: (BuildContext context) {
+            for (final text in textWidgets) {
+              final textWidth =
+                  getTextSize(context, text.data!.trim(), textStyle).width;
+              expect(textWidth <= maxWidth, isTrue);
+            }
+            return const SizedBox();
+          },
+        ),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
안녕하세요

아래의 이미지처럼 긴 문장이 주어진 경우 줄넘김이 부자연스러운 부분 수정했습니다. 알고리즘은 다음과 같습니다. 쪼개진 어절들의 텍스트 너비를 구합니다. 그 후 해당 텍스트의 너비가 주어진 공간의 최대 너비보다 큰 경우 계속해서 해당 어절을 쪼갭니다.
|수정 전|수정 후|
|------|-----|
|![스크린샷 2022-01-25 오후 12 07 15](https://user-images.githubusercontent.com/57604817/150910801-ee681fc4-cf07-49f1-96cc-37e6cadcde7f.png)|![스크린샷 2022-01-25 오후 12 06 29](https://user-images.githubusercontent.com/57604817/150910828-4000f903-8d13-420e-a7e2-243e4b9e231b.png)|



또한 테스팅을 할 수 있도록 `WordBreakTextFinder`을 추가했습니다.

